### PR TITLE
fixed error with missing key prop

### DIFF
--- a/src/components/navigation/Navbar.tsx
+++ b/src/components/navigation/Navbar.tsx
@@ -190,7 +190,7 @@ export default function Navbar() {
 				</div>
 				<div className="hidden lg:flex space-x-8 text-[17px] font-semibold absolute left-1/2 transform -translate-x-1/2">
 					{mainMenuItems.map((item) => (
-						<Link href={item.href} className="hover:underline">
+						<Link key={item.title} href={item.href} className="hover:underline">
 							{item.title}
 						</Link>
 					))}


### PR DESCRIPTION
Running the code from the `redesign` branch gives a `Warning: Each child in a list should have a unique "key" prop.` 
Components/Navigation/Navbar.tsx Line 193
This is solved by setting any unique value to the key prop, which in this case I set as the item's title.

Before:
`<Link href={item.href} className="hover:underline">`
After:
`<Link key={item.title} href={item.href} className="hover:underline">`